### PR TITLE
Fix post metadata layout

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -136,6 +136,8 @@ body {
 
     > main {
         flex: 1;
+        display: flex;
+        flex-direction: column;
     }
 
     > footer {
@@ -313,6 +315,10 @@ nav.media-nav {
 
 .layout-article,
 .layout-fiction {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+
     header {
         display: flex;
         flex-direction: column;
@@ -336,6 +342,7 @@ nav.media-nav {
 }
 
 article {
+    flex: 1;
     padding: var(--size-2);
 
     h1 {


### PR DESCRIPTION
Before:

<img width="721" alt="Screenshot 2025-04-16 at 8 59 53 am" src="https://github.com/user-attachments/assets/70ac597e-54f1-4db4-b2c0-c13d49750b8e" />

After:

<img width="721" alt="Screenshot 2025-04-16 at 8 59 54 am" src="https://github.com/user-attachments/assets/f4063dc3-52b5-4576-844e-360f0e987858" />
