### PR TITLE
Fix style of the media nav list

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -174,6 +174,8 @@ nav.media-nav {
     $final: $initial * 2;
 
     > ul {
+        margin-right: 0;
+
         > li {
             margin-bottom: var(--size-2);
 
@@ -182,6 +184,7 @@ nav.media-nav {
                 flex-direction: row;
                 justify-content: flex-start;
                 align-items: center;
+                text-align: left;
 
                 > .frame {
                     position: relative;


### PR DESCRIPTION
Before:

<img width="407" alt="Screenshot 2025-06-26 at 7 48 02 pm" src="https://github.com/user-attachments/assets/3921bce9-356f-47cc-b457-879f93e82908" />

After:

<img width="407" alt="Screenshot 2025-06-26 at 7 48 09 pm" src="https://github.com/user-attachments/assets/0b405153-5faa-430d-956d-aad08efea23d" />